### PR TITLE
Parse multiple comment characters in git messages

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_git_commit::language()).expect("Error loading git_commit grammar");
+//! parser.set_language(tree_sitter_gitcommit::language()).expect("Error loading git_commit grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!


### PR DESCRIPTION
Allow for alternate comment characters.

Git allows the [comment character](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corecommentChar)
for commands such as commit and tag to be changed. The original tree-sitter grammar only expects `#` to be used and fails to highlight commit messages if an alternate character is used. This change adds a fixed list of additional characters, copied from [neovim].

[neovim] https://github.com/neovim/neovim/blob/2b21c9c23f889555dd93ba508a0f787b25ed9bb4/runtime/ftplugin/gitcommit.vim#L21

I'm still figuring out how to re-compile the grammar and test locally. I've opened the PR to allow for any major faults to be pointed out right away.